### PR TITLE
Fix/creation-args

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,7 +11,7 @@ contract Deploy is Script {
 
   // default values
   bool internal _verbose = true;
-  string internal _version = "0.1.0"; // increment this with each new deployment
+  string internal _version = "0.1.1"; // increment this with each new deployment
   address internal _feeSplitRecipient = 0x58C8854a8E51BdCE9F00726B966905FE2719B4D9;
   uint256 internal _feeSplitPercentage = 500; // 5%
 
@@ -87,7 +87,6 @@ contract DeployInstance is Script {
   uint256 internal _saltNonce = 2;
   uint256 internal _hatId = 0x0000020f00010001000000000000000000000000000000000000000000000000;
   address internal _unlockFactory = 0x36b34e10295cCE69B652eEB5a8046041074515Da; // sepolia
-  PublicLockV14Eligibility.LockConfig internal _lockConfig;
 
   // lock config defaults
   uint256 internal _expirationDuration = 30 days;
@@ -103,13 +102,23 @@ contract DeployInstance is Script {
     address implementation,
     uint256 hatId,
     uint256 saltNonce,
-    PublicLockV14Eligibility.LockConfig memory lockConfig
+    uint256 expirationDuration,
+    address tokenAddress,
+    uint256 keyPrice,
+    uint256 maxNumberOfKeys,
+    address lockManager,
+    string memory lockName
   ) public {
     _verbose = verbose;
     _implementation = implementation;
     _hatId = hatId;
     _saltNonce = saltNonce;
-    _lockConfig = lockConfig;
+    _expirationDuration = expirationDuration;
+    _tokenAddress = tokenAddress;
+    _keyPrice = keyPrice;
+    _maxNumberOfKeys = maxNumberOfKeys;
+    _lockManager = lockManager;
+    _lockName = lockName;
   }
 
   /// @dev Set up the deployer via their private key from the environment
@@ -129,22 +138,13 @@ contract DeployInstance is Script {
   function run() public virtual returns (PublicLockV14Eligibility) {
     vm.startBroadcast(deployer());
 
-    // use the default values if the prepared lockConfig is empty
-    if (_lockConfig.expirationDuration == 0) {
-      _lockConfig.expirationDuration = _expirationDuration;
-      _lockConfig.tokenAddress = _tokenAddress;
-      _lockConfig.keyPrice = _keyPrice;
-      _lockConfig.maxNumberOfKeys = _maxNumberOfKeys;
-      _lockConfig.lockManager = _lockManager;
-      _lockConfig.lockName = _lockName;
-    }
-
     instance = PublicLockV14Eligibility(
       factory.createHatsModule(
         _implementation,
         _hatId,
         abi.encodePacked(), // other immutable args
-        abi.encode(_lockConfig), // init data
+        abi.encode(_expirationDuration, _tokenAddress, _keyPrice, _maxNumberOfKeys, _lockManager, _lockName), // init
+          // data
         _saltNonce
       )
     );

--- a/src/PublicLockV14Eligibility.sol
+++ b/src/PublicLockV14Eligibility.sol
@@ -39,19 +39,6 @@ contract PublicLockV14Eligibility is HatsEligibilityModule, ILockKeyPurchaseHook
   event ImplementationReferrerFeePercentageSet(uint256 referrerFeePercentage);
 
   /*//////////////////////////////////////////////////////////////
-                            DATA MODELS
-  //////////////////////////////////////////////////////////////*/
-
-  struct LockConfig {
-    uint256 expirationDuration;
-    address tokenAddress;
-    uint256 keyPrice;
-    uint256 maxNumberOfKeys;
-    address lockManager;
-    string lockName;
-  }
-
-  /*//////////////////////////////////////////////////////////////
                             CONSTANTS 
   //////////////////////////////////////////////////////////////*/
 
@@ -130,17 +117,24 @@ contract PublicLockV14Eligibility is HatsEligibilityModule, ILockKeyPurchaseHook
   /// @inheritdoc HatsModule
   function _setUp(bytes calldata _initData) internal override {
     // decode init data
-    LockConfig memory lockConfig = abi.decode(_initData, (LockConfig));
+    (
+      uint256 _expirationDuration,
+      address _tokenAddress,
+      uint256 _keyPrice,
+      uint256 _maxNumberOfKeys,
+      address _lockManager,
+      string memory _lockName
+    ) = abi.decode(_initData, (uint256, address, uint256, uint256, address, string));
 
     // encode the lock init data
     bytes memory lockInitData = abi.encodeWithSignature(
       "initialize(address,uint256,address,uint256,uint256,string)",
       address(this),
-      lockConfig.expirationDuration,
-      lockConfig.tokenAddress,
-      lockConfig.keyPrice,
-      lockConfig.maxNumberOfKeys,
-      lockConfig.lockName
+      _expirationDuration,
+      _tokenAddress,
+      _keyPrice,
+      _maxNumberOfKeys,
+      _lockName
     );
 
     // create the new lock
@@ -165,7 +159,7 @@ contract PublicLockV14Eligibility is HatsEligibilityModule, ILockKeyPurchaseHook
     lock.setReferrerFee(REFERRER, fee);
 
     // add lock manager role to the configured address
-    lock.addLockManager(lockConfig.lockManager);
+    lock.addLockManager(_lockManager);
     // revokes itself lock manager
     lock.renounceLockManager();
   }

--- a/src/PublicLockV14Eligibility.sol
+++ b/src/PublicLockV14Eligibility.sol
@@ -191,7 +191,7 @@ contract PublicLockV14Eligibility is HatsEligibilityModule, ILockKeyPurchaseHook
     address, /* recipient */
     address, /* referrer */
     bytes calldata /* data */
-  ) external view returns (uint256 minKeyPrice) {
+  ) public view returns (uint256 minKeyPrice) {
     // Check if referrer fee is correct. Fail minting if incorrect.
     if (lock.referrerFees(REFERRER) != referrerFeePercentage) {
       revert InvalidReferrerFee();
@@ -295,6 +295,13 @@ contract PublicLockV14Eligibility is HatsEligibilityModule, ILockKeyPurchaseHook
   /// @notice Convenience function to get the max number of keys from the lock
   function maxNumberOfKeys() external view returns (uint256) {
     return lock.maxNumberOfKeys();
+  }
+
+  /// @notice Convenience function to get the key price from the lock
+  /// @dev This function wraps the main {keyPurchasePrice} function to enable it to be called without arguments, eg by
+  /// the Hats Modules SDK
+  function keyPurchasePrice() external view returns (uint256) {
+    return this.keyPurchasePrice(address(0), address(0), address(0), bytes(""));
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/test/PublicLockEligibility.t.sol
+++ b/test/PublicLockEligibility.t.sol
@@ -355,6 +355,10 @@ contract KeyPurchasePrice is WithInstanceTest {
     vm.expectRevert(PublicLockV14Eligibility.InvalidReferrerFee.selector);
     instance.keyPurchasePrice(address(0), address(0), address(0), bytes(""));
   }
+
+  function test_convenienceFunction() public view {
+    assertEq(instance.keyPurchasePrice(), instance.keyPurchasePrice(address(0), address(0), address(0), bytes("")));
+  }
 }
 
 contract OnKeyPurchase is WithInstanceTest {


### PR DESCRIPTION
Switch away from struct-encoded creation args for better compatibility with the modules registry.

Also adds a `keyPurchasePrice()` convenience function that is compatible with the modules registry.