### PR TITLE
Multichain-deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ When users purchase a key, they are also automatically minted the hat. To remain
 
 The module must serve as both a Hats eligibility module and a hatter contract. To mint the target hat when a user purchases a new key, it must be an amin of hte target hat — i.e. wear one of the target hat's admin hats — which makes it a hatter contract. To control eligibility for the target hat, it must also be set as the eligibility module for the target hat.
 
+## Implementation Deployment
+
+In order to deploy a new implementation — eg to a new network — you must not only call the constructor but also the `setUnlock()` initializer function. This function sets the address of the Unlock contract that instances created from the new implementation will use. This is separate from the constructor to enable deployment to use the same initCode and therefore achieve the same address across multiple chains, even though the Unlock address differs by chain.
+
+The full flow is included in the `script/Deploy.s.sol` script.
+
 ## Development
 
 This repo uses Foundry for development and testing. To get started:

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,7 +11,7 @@ contract Deploy is Script {
 
   // default values
   bool internal _verbose = true;
-  string internal _version = "0.1.1"; // increment this with each new deployment
+  string internal _version = "0.1.2"; // increment this with each new deployment
   address internal _feeSplitRecipient = 0x58C8854a8E51BdCE9F00726B966905FE2719B4D9;
   uint256 internal _feeSplitPercentage = 500; // 5%
 
@@ -69,7 +69,10 @@ contract Deploy is Script {
      *    2. The provided salt, `SALT`
      */
     implementation =
-      new PublicLockV14Eligibility{ salt: SALT }(_version, getUnlockAddress(), _feeSplitRecipient, _feeSplitPercentage);
+      new PublicLockV14Eligibility{ salt: SALT }(_version, _feeSplitRecipient, _feeSplitPercentage, deployer());
+
+    // set the unlock address on the implementation
+    implementation.setUnlock(getUnlockAddress());
 
     vm.stopBroadcast();
 

--- a/script/Deployments.json
+++ b/script/Deployments.json
@@ -40,7 +40,7 @@
     "unlockDeploymentBlock": 13994123
   },
   "100": {
-    "hatsModuleFactoryDeploymentBlock": 34772144,
+    "hatsModuleFactoryDeploymentBlock": 36005519,
     "unlock": "0x1bc53f4303c711cc693F6Ec3477B83703DcB317f",
     "unlockDeploymentBlock": 19338710
   },


### PR DESCRIPTION
Changes the implementation deployment flow to ensure that deployments to EVM chains are always to the same address.

Since the unlock protocol address differs by network, we set in an initializer rather than the constructor to keep the initCode constant across networks.